### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Autoloader/ClassPathMapper/Application.php
+++ b/lib/Horde/Autoloader/ClassPathMapper/Application.php
@@ -23,6 +23,7 @@
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   Autoloader
  */
+#[\AllowDynamicProperties]
 class Horde_Autoloader_ClassPathMapper_Application
 implements Horde_Autoloader_ClassPathMapper
 {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Autoloader/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Autoloader/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Autoloader Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Autoloader/AutoloaderTest.php
+++ b/test/Horde/Autoloader/AutoloaderTest.php
@@ -1,5 +1,5 @@
 <?php
-class Horde_Autoloader_AutoloaderTest extends PHPUnit_Framework_TestCase
+class Horde_Autoloader_AutoloaderTest extends Horde_Test_Case
 {
     private $_autoloader;
 

--- a/test/Horde/Autoloader/AutoloaderTest.php
+++ b/test/Horde/Autoloader/AutoloaderTest.php
@@ -3,7 +3,7 @@ class Horde_Autoloader_AutoloaderTest extends Horde_Test_Case
 {
     private $_autoloader;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_autoloader = new Horde_Autoloader_TestHarness();
     }
@@ -74,7 +74,9 @@ class Horde_Autoloader_AutoloaderTest extends Horde_Test_Case
 
     private function _getSuccessfulMapperMock()
     {
-        $mapper = $this->getMock('Horde_Autoloader_ClassPathMapper', array('mapToPath'));
+        $mapper = $this->getMockBuilder('Horde_Autoloader_ClassPathMapper')
+                       ->setMethods(array('mapToPath'))
+                       ->getMock();
         $mapper->expects($this->once())
             ->method('mapToPath')
             ->with($this->equalTo('The_Class_Name'))
@@ -85,7 +87,9 @@ class Horde_Autoloader_AutoloaderTest extends Horde_Test_Case
 
     private function _getUnsuccessfulMapperMock()
     {
-        $mapper = $this->getMock('Horde_Autoloader_ClassPathMapper', array('mapToPath'));
+        $mapper = $this->getMockBuilder('Horde_Autoloader_ClassPathMapper')
+                       ->setMethods(array('mapToPath'))
+                       ->getMock();
         $mapper->expects($this->once())
             ->method('mapToPath')
             ->with($this->equalTo('The_Class_Name'))

--- a/test/Horde/Autoloader/ClassPathMapper/ApplicationTest.php
+++ b/test/Horde/Autoloader/ClassPathMapper/ApplicationTest.php
@@ -3,7 +3,7 @@
  * @category Horde
  * @package  Autoloader
  */
-class Horde_Autoloader_ClassPathMapper_ApplicationTest extends PHPUnit_Framework_TestCase
+class Horde_Autoloader_ClassPathMapper_ApplicationTest extends Horde_Test_Case
 {
     private $_mapper;
 

--- a/test/Horde/Autoloader/ClassPathMapper/ApplicationTest.php
+++ b/test/Horde/Autoloader/ClassPathMapper/ApplicationTest.php
@@ -7,7 +7,7 @@ class Horde_Autoloader_ClassPathMapper_ApplicationTest extends Horde_Test_Case
 {
     private $_mapper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_mapper = new Horde_Autoloader_ClassPathMapper_Application(
             'app' // directory to app dir

--- a/test/Horde/Autoloader/ClassPathMapper/DefaultTest.php
+++ b/test/Horde/Autoloader/ClassPathMapper/DefaultTest.php
@@ -3,7 +3,7 @@
  * @category Horde
  * @package  Autoloader
  */
-class Horde_Autoloader_ClassPathMapper_DefaultTest extends PHPUnit_Framework_TestCase
+class Horde_Autoloader_ClassPathMapper_DefaultTest extends Horde_Test_Case
 {
     private $_mapper;
 

--- a/test/Horde/Autoloader/ClassPathMapper/DefaultTest.php
+++ b/test/Horde/Autoloader/ClassPathMapper/DefaultTest.php
@@ -7,7 +7,7 @@ class Horde_Autoloader_ClassPathMapper_DefaultTest extends Horde_Test_Case
 {
     private $_mapper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_mapper = new Horde_Autoloader_ClassPathMapper_Default('dir');
     }

--- a/test/Horde/Autoloader/ClassPathMapper/PrefixStringTest.php
+++ b/test/Horde/Autoloader/ClassPathMapper/PrefixStringTest.php
@@ -4,7 +4,7 @@
  * @package  Autoloader
  */
 class Horde_Autoloader_ClassPathMapper_PrefixStringTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     private $_mapper;
 

--- a/test/Horde/Autoloader/ClassPathMapper/PrefixStringTest.php
+++ b/test/Horde/Autoloader/ClassPathMapper/PrefixStringTest.php
@@ -8,7 +8,7 @@ extends Horde_Test_Case
 {
     private $_mapper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_mapper = new Horde_Autoloader_ClassPathMapper_PrefixString(
             'App',

--- a/test/Horde/Autoloader/ClassPathMapper/PrefixTest.php
+++ b/test/Horde/Autoloader/ClassPathMapper/PrefixTest.php
@@ -3,7 +3,7 @@
  * @category Horde
  * @package  Autoloader
  */
-class Horde_Autoloader_ClassPathMapper_PrefixTest extends PHPUnit_Framework_TestCase
+class Horde_Autoloader_ClassPathMapper_PrefixTest extends Horde_Test_Case
 {
     private $_mapper;
 

--- a/test/Horde/Autoloader/ClassPathMapper/PrefixTest.php
+++ b/test/Horde/Autoloader/ClassPathMapper/PrefixTest.php
@@ -7,7 +7,7 @@ class Horde_Autoloader_ClassPathMapper_PrefixTest extends Horde_Test_Case
 {
     private $_mapper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_mapper = new Horde_Autoloader_ClassPathMapper_Prefix('/^App(?:$|_)/i', 'dir');
     }


### PR DESCRIPTION
- Debian changes: s/PHPUnit_Framework_TestCase/Horde_Test_Case/g https://salsa.debian.org/horde-team/php-horde-autoloader/-/blob/debian-sid/debian/patches/0001-s-PHPUnit_Framework_TestCase-Horde_Test_Case-g.patch
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-autoloader/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-autoloader/-/blob/debian-sid/debian/patches/1012_php8.2.patch
