### PR TITLE
fix setlocale

### DIFF
--- a/lib/Horde/Autoloader.php
+++ b/lib/Horde/Autoloader.php
@@ -150,7 +150,7 @@ class Horde_Autoloader
      */
     protected function _lower($string)
     {
-        $language = setlocale(LC_CTYPE, 0);
+        $language = setlocale(LC_CTYPE, '0');
         setlocale(LC_CTYPE, 'C');
         $string = strtolower($string);
         setlocale(LC_CTYPE, $language);

--- a/lib/Horde/Autoloader/ClassPathMapper/PrefixString.php
+++ b/lib/Horde/Autoloader/ClassPathMapper/PrefixString.php
@@ -78,7 +78,7 @@ implements Horde_Autoloader_ClassPathMapper
      */
     protected function _ipos($haystack, $needle)
     {
-        $language = setlocale(LC_CTYPE, 0);
+        $language = setlocale(LC_CTYPE, '0');
         setlocale(LC_CTYPE, 'C');
         $pos = stripos($haystack, $needle);
         setlocale(LC_CTYPE, $language);

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -154,7 +154,7 @@ class Autoloader
      */
     protected function _lower(string $string): string
     {
-        $language = setlocale(LC_CTYPE, 0);
+        $language = setlocale(LC_CTYPE, '0');
         setlocale(LC_CTYPE, 'C');
         $string = strtolower($string);
         setlocale(LC_CTYPE, $language);

--- a/src/ClassPathMapper/PrefixString.php
+++ b/src/ClassPathMapper/PrefixString.php
@@ -77,7 +77,7 @@ class PrefixString implements ClassPathMapper
      */
     protected function _ipos(string $haystack, string $needle): int|false
     {
-        $language = setlocale(LC_CTYPE, 0);
+        $language = setlocale(LC_CTYPE, '0');
         setlocale(LC_CTYPE, 'C');
         $pos = stripos($haystack, $needle);
         setlocale(LC_CTYPE, $language);


### PR DESCRIPTION
This will fix setlocale to provide the proper type.

Changed: $locale = setlocale(LC_ALL, 0);
to: $locale = setlocale(LC_ALL, '0');

will change it to null if preferred.

Going to do this for horde/date, horde/util, horde/autoloader as well.

@ralflang , @TDannhauer